### PR TITLE
BMS-6756 - add function to sanitize req.params

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ app.use(expressSanitized()); // this line follows app.use(bodyParser.json) or th
 
 ```
 
+The above sanitizes `req.body` and `req.query`.  In order to sanitize `req.params` as well, pass in an express router or app to `expressSanitized.sanitizeParams`,
+along with the names of the params to sanitize, e.g.:
+
+```javascript
+var express = require('express');
+var expressSanitized = require('express-sanitize-escape');
+
+var router = express.router();
+expressSanitized.sanitizeParams(router, ['id','name']);
+
+router.get('/:id', function(req, res, next)
+{
+    // req.params.id is now sanitized.
+    ...
+});
+
+router.get('/:name', function(req, res, next)
+{
+    // req.params.name is now sanitized.
+    ...
+});
+```
+
 
 ## Output
 
@@ -34,8 +57,8 @@ The string
 will be sanitized to ' download now'.
 
 and
-```javascript
-'< > ' " &'
+```
+< > ' " &
 ```
 will be escaped to `&lt; &gt; &#39; &quot; &amp;`
 
@@ -54,6 +77,9 @@ This module was inspired by [express-sanitizer](https://www.npmjs.org/package/ex
   And automatically html escapes all strings.
 
 ## Changelog
+
+### v0.6.3
+- Added function to sanitize request params of a router
 
 ### v0.6.1
 - Added additional test for nested object and an array

--- a/lib/express-sanitize-escape.js
+++ b/lib/express-sanitize-escape.js
@@ -26,7 +26,7 @@ module.exports = function expressSanitized() {
 
     return function expressSanitized(req, res, next) {
 
-        [req.body, req.query].forEach(function (val, ipar, request) {
+        [req.body, req.query, req.params].forEach(function (val, ipar, request) {
             if (_.size(val)) {
                 request[ipar] = sanitize(request[ipar])
             }

--- a/lib/express-sanitize-escape.js
+++ b/lib/express-sanitize-escape.js
@@ -26,7 +26,7 @@ module.exports = function expressSanitized() {
 
     return function expressSanitized(req, res, next) {
 
-        [req.body, req.query, req.params].forEach(function (val, ipar, request) {
+        [req.body, req.query].forEach(function (val, ipar, request) {
             if (_.size(val)) {
                 request[ipar] = sanitize(request[ipar])
             }
@@ -36,6 +36,19 @@ module.exports = function expressSanitized() {
     }
 
 };
+
+module.exports.sanitizeParams = function(router, paramNames)
+{
+    paramNames.forEach(function(paramName)
+    {
+        router.param(paramName, function(req, res, next)
+        {
+            req.params[paramName] = sanitize(req.params[paramName]);
+
+            next();
+        });
+    });
+}
 
 function sanitize(obj) {
     if (typeof obj === 'string') {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-sanitize-escape",
   "description": "Express middleware for the sanitizer module using Caja's HTML Sanitizer and HTML escape using htmlencode.",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": "Justin Hamade <justin@fingerfoodstudios.com>",
   "homepage": "https://github.com/fingerfoodstudios/express-sanitize-esacpe",
   "bugs": {


### PR DESCRIPTION
`req.params` is not populated at the time that middleware is called, so it can't be sanitized with `req.query` and `req.body`. 

This change adds a function `sanitizeParams` which takes a router and a list of param names and sanitizes all params coming through the router.

Example:

```
var router = express.router();
expressSanitized.sanitizeParams(router, ['id', 'token']);
router.get('/:id/:token', function(req, res, next)
{
    // req.params.id and req.params.token are sanitized.
    ...
});
```
